### PR TITLE
Try to fix bug on spot instances.

### DIFF
--- a/pkg/cloud/aws/provider.go
+++ b/pkg/cloud/aws/provider.go
@@ -673,6 +673,9 @@ func (k *awsKey) getUsageType(labels map[string]string) string {
 	if kLabel, ok := labels[models.KarpenterCapacityTypeLabel]; ok && kLabel == models.KarpenterCapacitySpotTypeValue {
 		return PreemptibleType
 	}
+	if spotLabel, ok := labels[k.SpotLabelName]; ok && spotLabel == k.SpotLabelValue {
+		return PreemptibleType
+	}
 	return ""
 }
 


### PR DESCRIPTION
It seems the getusage type only works for eks or if we have karpenter tags. I expanded it to use the custom spot tag we setup on the configuration. this should work in any cluster scenario if the person configure the right tag. 

before this it was returning key with a trailing comma as described bellow:  us-west-2,c5.4xlarge,linux,

## What does this PR change?
* 

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
